### PR TITLE
Disable nvidia_drm.modeset to fix blank screens after login

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nvidia-graphics-drivers-430 (430.34-1pop2) bionic; urgency=medium
+
+  * Disable nvidia_drm.modeset to fix blank screens after login
+
+ -- Jeremy Soller <jeremy@system76.com>  Fri, 26 Jul 2019 07:48:06 -0600
+
 nvidia-graphics-drivers-430 (430.34-1pop1) bionic; urgency=medium
 
   * Upstream release

--- a/debian/nvidia-graphics-drivers.conf
+++ b/debian/nvidia-graphics-drivers.conf
@@ -3,4 +3,3 @@ blacklist lbm-nouveau
 alias nouveau off
 alias lbm-nouveau off
 
-options nvidia-drm modeset=1

--- a/debian/templates/nvidia-graphics-drivers.conf.in
+++ b/debian/templates/nvidia-graphics-drivers.conf.in
@@ -3,4 +3,3 @@ blacklist lbm-nouveau
 alias nouveau off
 alias lbm-nouveau off
 
-options nvidia-drm modeset=1


### PR DESCRIPTION
This should be merged with https://github.com/pop-os/system76-driver/pull/117