### PR TITLE
fix: Fix CUDA functionality after resuming from suspension

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -107,7 +107,9 @@ ifeq ($(DEB_HOST_ARCH),amd64)
 endif
 
 	dh_install -p nvidia-compute-utils-$(version_major)
-	mkdir -p $(CURDIR)/debian/nvidia-compute-utils-$(version_major)/lib/systemd
+	mkdir -p $(CURDIR)/debian/nvidia-compute-utils-$(version_major)/lib/systemd \
+	    $(CURDIR)/debian/nvidia-compute-utils-$(version_major)/usr/lib/system-sleep
+	cp $(CURDIR)/reload-nvidia-uvm.sh  $(CURDIR)/debian/nvidia-compute-utils-$(version_major)/usr/lib/system-sleep/
 	dh_systemd_enable --name=nvidia-persistenced
 	dh_install -p nvidia-kernel-common-$(version_major)
 

--- a/reload-nvidia-uvm.sh
+++ b/reload-nvidia-uvm.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# CUDA fails to initialize after resuming from suspend with `UNKNOWN_ERROR(99)`
+# until we reload the `nvidia_uvm` module.
+
+if test "${1}" = "post" && grep nvidia_uvm /proc/modules >/dev/null; then
+	echo "Reloading nvidia_uvm kernel module"
+	rmmod nvidia_uvm
+	modprobe nvidia_uvm
+fi
+


### PR DESCRIPTION
CUDA fails to initialize after resuming from suspend with `UNKNOWN_ERROR(99)` until we reload the `nvidia_uvm` module.