### PR TITLE
WIP: Add RTD3 power management configuration

### DIFF
--- a/debian/80-nvidia-pm.rules
+++ b/debian/80-nvidia-pm.rules
@@ -1,0 +1,16 @@
+# Remove NVIDIA USB xHCI Host Controller devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
+
+# Remove NVIDIA USB Type-C UCSI devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
+
+# Remove NVIDIA Audio devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
+
+# Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"
+
+# Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
+ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="on"
+ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="on"

--- a/debian/nvidia-graphics-drivers.conf
+++ b/debian/nvidia-graphics-drivers.conf
@@ -4,3 +4,4 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
+options nvidia "NVreg_DynamicPowerManagement=0x02"

--- a/debian/nvidia-kernel-common-435.install
+++ b/debian/nvidia-kernel-common-435.install
@@ -1,4 +1,5 @@
 debian/71-nvidia.rules                                               lib/udev/rules.d
+debian/80-nvidia-pm.rules                                               lib/udev/rules.d
 debian/create-uvm-dev-node                                           sbin
 debian/framebuffer-nvidia                                            usr/share/initramfs-tools/hooks
 debian/nvidia-graphics-drivers.conf                                  lib/modprobe.d

--- a/debian/templates/nvidia-kernel-common-flavour.install.in
+++ b/debian/templates/nvidia-kernel-common-flavour.install.in
@@ -1,4 +1,5 @@
 debian/71-nvidia.rules                                               lib/udev/rules.d
+debian/80-nvidia-pm.rules                                               lib/udev/rules.d
 debian/create-uvm-dev-node                                           sbin
 debian/framebuffer-nvidia                                            usr/share/initramfs-tools/hooks
 debian/nvidia-graphics-drivers.conf                                  lib/modprobe.d


### PR DESCRIPTION
Adds the [configuration to enable RTD3 power management](http://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/dynamicpowermanagement.html#AutomatedSetup803b0) for Turing GPUs.

Currently this causes the system76-power daemon to freeze pop-os/system76-power#122