### PR TITLE
Enable dynamic power management

### DIFF
--- a/debian/nvidia-graphics-drivers.conf
+++ b/debian/nvidia-graphics-drivers.conf
@@ -4,3 +4,4 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
+options nvidia NVreg_DynamicPowerManagement=2

--- a/debian/templates/nvidia-graphics-drivers.conf.in
+++ b/debian/templates/nvidia-graphics-drivers.conf.in
@@ -4,3 +4,4 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
+options nvidia NVreg_DynamicPowerManagement=2


### PR DESCRIPTION
Always enable run-time power management in the driver. While only useful for PRIME configurations (hybrid graphics), it does not impact use in NVIDIA-only mode.

This removes the need to conditionally set it in `/etc/modprobe.d/system76-power.conf` when using `system76-power`.