### PR TITLE
Install supported-gpus.json

### DIFF
--- a/debian/nvidia-driver-455.docs
+++ b/debian/nvidia-driver-455.docs
@@ -8,3 +8,4 @@ NVIDIA-Linux/nvidia-persistenced-init.tar.bz2
 NVIDIA-Linux/nvidia-resume.service
 NVIDIA-Linux/nvidia-sleep.sh
 NVIDIA-Linux/nvidia-suspend.service
+NVIDIA-Linux/supported-gpus.json

--- a/debian/rules
+++ b/debian/rules
@@ -126,6 +126,9 @@ override_dh_clean: regen-from-templates
 	rm -f $(AUTOCLEAN)
 	$(MAKE) -f debian/rules $(AUTOKEEP)
 
+override_dh_compress:
+	dh_compress -X.json
+
 override_dh_auto_configure: prepare regen-from-templates remove-stack-markings
 
 override_dh_install: generate-modaliases build-device-create

--- a/debian/templates/nvidia-driver-flavour.docs.in
+++ b/debian/templates/nvidia-driver-flavour.docs.in
@@ -8,3 +8,4 @@
 #I386_EXCLUDED#NVIDIA-Linux/nvidia-resume.service
 #I386_EXCLUDED#NVIDIA-Linux/nvidia-sleep.sh
 #I386_EXCLUDED#NVIDIA-Linux/nvidia-suspend.service
+#I386_EXCLUDED#NVIDIA-Linux/supported-gpus.json


### PR DESCRIPTION
Add the new doc file used to query GPU features. gpu-manager 0.8.6 uses this to configure run-time power management.