### PR TITLE
fix: Set NVreg_PreserveVideoMemoryAllocations=1 on Nvidia and Hybrid

### DIFF
--- a/debian/nvidia-graphics-drivers.conf
+++ b/debian/nvidia-graphics-drivers.conf
@@ -4,3 +4,4 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
+options nvidia NVreg_PreserveVideoMemoryAllocations=1

--- a/debian/templates/nvidia-graphics-drivers.conf.in
+++ b/debian/templates/nvidia-graphics-drivers.conf.in
@@ -4,3 +4,4 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
+options nvidia NVreg_PreserveVideoMemoryAllocations=1


### PR DESCRIPTION
Hopefully this should help with the suspend/resume issues with WebRender. Requires testing to make sure it fixes the issue and doesn't cause others.

Related: pop-os/default-settings#104 and pop-os/default-settings#105.