### PR TITLE
Revert "fix: Set NVreg_PreserveVideoMemoryAllocations=1 on Nvidia and Hybrid"

### DIFF
--- a/debian/nvidia-graphics-drivers.conf
+++ b/debian/nvidia-graphics-drivers.conf
@@ -4,4 +4,3 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
-options nvidia NVreg_PreserveVideoMemoryAllocations=1

--- a/debian/templates/nvidia-graphics-drivers.conf.in
+++ b/debian/templates/nvidia-graphics-drivers.conf.in
@@ -4,4 +4,3 @@ alias nouveau off
 alias lbm-nouveau off
 
 options nvidia-drm modeset=1
-options nvidia NVreg_PreserveVideoMemoryAllocations=1


### PR DESCRIPTION
This reverts commit de515f69a4816b6e11633faba2d11b1f2a738c55.

`NVreg_PreserveVideoMemoryAllocations` should not be used with S0ix.
Instead, these systems must enable S0ix-based power management with
`NVreg_EnableS0ixPowerManagement=1` [\[1\]].

Configuring these settings must be moved to system76-power or
system76-driver to handle this difference between sleep modes.

[\[1\]]: https://download.nvidia.com/XFree86/Linux-x86_64/470.86/README/powermanagement.html#PreserveAllVide719f0