### PR TITLE
Explicitly test Steam in more graphics modes

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -20,6 +20,9 @@ Several graphics cards will have to be tested, preferably in several desktops. T
 - [ ] Multiple displays at once work as expected
 - [ ] GSync over DisplayPort is working without flickering or flashing
 - [ ] Multiple NVIDIA GPUs in a desktop are correctly reported by `nvidia-smi`
+- [ ] Steam can be installed and launched
+- [ ] A native Linux game can be launched from Steam
+- [ ] A Proton game can be launched from Steam
 
 ## Laptop graphics (switchable graphics)
 
@@ -34,6 +37,9 @@ Switchable graphics laptops can render with either the CPU-integrated GPU or the
 - [ ] DisplayPort (mDP and DP over USB-C) outputs (including sound) work as expected
 - [ ] HDMI-out (including sound) works as expected
 - [ ] External display becomes primary display when laptop lid is closed
+- [ ] Steam can be installed and launched
+- [ ] A native Linux game can be launched from Steam
+- [ ] A Proton game can be launched from Steam
 
 ### NVIDIA mode tests
 
@@ -42,6 +48,9 @@ Switchable graphics laptops can render with either the CPU-integrated GPU or the
 - [ ] DisplayPort (mDP and DP over USB-C) outputs (including sound) work as expected
 - [ ] HDMI-out (including sound) works as expected
 - [ ] External display becomes primary display when laptop lid is closed
+- [ ] Steam can be installed and launched
+- [ ] A native Linux game can be launched from Steam
+- [ ] A Proton game can be launched from Steam
 
 ### Compute mode tests
 
@@ -51,6 +60,9 @@ Switchable graphics laptops can render with either the CPU-integrated GPU or the
 ### Integrated mode test
 
 - [ ] Plugging in a display correctly prompts to switch to Hybrid mode
+- [ ] Steam can be installed and launched
+- [ ] A native Linux game can be launched from Steam
+- [ ] A Proton game can be launched from Steam
 
 ## Software tests
 
@@ -58,6 +70,3 @@ These can be done on any machine with an NVIDIA GPU
 
 - [ ] NVIDIA X Server Settings application launches properly
 - [ ] A Unigine benchmark performs as expected
-- [ ] Steam can be installed and launched
-- [ ] A native Linux game can be launched from Steam
-- [ ] A Proton game can be launched from Steam

--- a/TESTING.md
+++ b/TESTING.md
@@ -21,6 +21,10 @@ Several graphics cards will have to be tested, preferably in several desktops. T
 - [ ] GSync over DisplayPort is working without flickering or flashing
 - [ ] Multiple NVIDIA GPUs in a desktop are correctly reported by `nvidia-smi`
 - [ ] Steam can be installed and launched
+  - [ ] From Launcher
+  - [ ] From App Library
+  - [ ] From Dock
+  - [ ] From Termial
 - [ ] A native Linux game can be launched from Steam
 - [ ] A Proton game can be launched from Steam
 
@@ -38,6 +42,10 @@ Switchable graphics laptops can render with either the CPU-integrated GPU or the
 - [ ] HDMI-out (including sound) works as expected
 - [ ] External display becomes primary display when laptop lid is closed
 - [ ] Steam can be installed and launched
+  - [ ] From Launcher
+  - [ ] From App Library
+  - [ ] From Dock
+  - [ ] From Termial
 - [ ] A native Linux game can be launched from Steam
 - [ ] A Proton game can be launched from Steam
 
@@ -49,6 +57,10 @@ Switchable graphics laptops can render with either the CPU-integrated GPU or the
 - [ ] HDMI-out (including sound) works as expected
 - [ ] External display becomes primary display when laptop lid is closed
 - [ ] Steam can be installed and launched
+  - [ ] From Launcher
+  - [ ] From App Library
+  - [ ] From Dock
+  - [ ] From Termial
 - [ ] A native Linux game can be launched from Steam
 - [ ] A Proton game can be launched from Steam
 
@@ -61,6 +73,10 @@ Switchable graphics laptops can render with either the CPU-integrated GPU or the
 
 - [ ] Plugging in a display correctly prompts to switch to Hybrid mode
 - [ ] Steam can be installed and launched
+  - [ ] From Launcher
+  - [ ] From App Library
+  - [ ] From Dock
+  - [ ] From Termial
 - [ ] A native Linux game can be launched from Steam
 - [ ] A Proton game can be launched from Steam
 


### PR DESCRIPTION
Testing in Integrated might be excessive, but if Steam and 2 games are already set up on a test machine, we might as well check that too.