### PR TITLE
Add nvidia drm drivers to initramfs

### DIFF
--- a/debian/nvidia-driver-515.postinst
+++ b/debian/nvidia-driver-515.postinst
@@ -1,0 +1,32 @@
+#!/bin/bash
+# postinst script for nvidia-driver-515
+#
+# see: dh_installdeb(1)
+#
+# Copyright (C) 2022 System76
+# Authors: Brock Szuszczewicz
+set -e
+
+# This postinst is to add Nvidia drm drivers to initramfs. This is required for
+# some systems when showing Plymouth in the initramfs
+
+# Make sure 120M is available in ESP
+is_enough_esp_space () {
+    efi=($(df | grep /boot/efi))
+    echo $((${efi[3]} > 120000))
+}
+
+# Return true if initramfs module is not added, or added incorrectly
+is_driver_added () {
+    [[ -r /usr/share/initramfs-tools/modules.d/system76-nvidia-initramfs.conf ]] \
+    && [[ "$(cat /usr/share/initramfs-tools/modules.d/system76-nvidia-initramfs.conf)" == $(echo -e "# Added by System76 Nvidia Packaging\nnvidia-drm\n") ]] \
+    && echo 1 \
+    || echo 0
+}
+
+if [[ `is_enough_esp_space` = 1 ]] && [[ `is_driver_added` = 0 ]]; then
+    echo $'# Added by System76 Nvidia Packaging\nnvidia-drm\n' > "/usr/share/initramfs-tools/modules.d/system76-nvidia-initramfs.conf"
+    update-initramfs -u
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
This should add the nvidia drivers to the initramfs for all systems that have the nvidia-driver-515 package installed, and have 120M free of ESP space

1) If this works, https://github.com/pop-os/system76-driver/pull/246 should be closed. Please check that this fixes the affected systems there, oryp6, oryp9, oryp10, mira-b1, and mega-r2 as well as general regression testing. 
2) Please also test for a system with less than 120M of free esp,
3) If possible test for OS upgrades. On broken systems like mega-r2, when doing an OS upgrade does the plymouth upgrade screen also break like the plymouth decrypt screen, if so, does this fix that? (on ubuntu and pop)