### PR TITLE
Fix nvidia-driver-515.postinst install on BIOS

### DIFF
--- a/debian/nvidia-driver-515.postinst
+++ b/debian/nvidia-driver-515.postinst
@@ -12,8 +12,9 @@ set -e
 
 # Make sure 120M is available in ESP
 is_enough_esp_space () {
-    efi=($(df | grep /boot/efi))
-    echo $((${efi[3]} > 120000))
+    efi=($(df | grep /boot/efi)) \
+    && echo $((${efi[3]} >= 120000)) \
+    || echo 0
 }
 
 # Return true if initramfs module is not added, or added incorrectly


### PR DESCRIPTION
Bios machines dont have a /boot/efi, thus df | grep /boot/efi fails, which causes the script to fail, which causes the nvidia drivers not to install.

This change just checks for the return value of grep, and if there is an error we return 0 so that the postinstall script exits gracefully.

Thanks @mikejaques for finding this bug and reporting it so quickly on our discord!