### PR TITLE
Make 515 transition to 525

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -354,6 +354,146 @@ Description: NVENC Video Encoding runtime library
  .
  This package contains the nvidia-encode runtime library.
 
+# 515 Transitional Packaging
+
+Package: nvidia-driver-515
+Architecture: amd64
+Depends: nvidia-driver-525
+Multi-Arch: foreign
+Description: Transitional package for nvidia-driver-525
+ This is a transitional package for nvidia-driver-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-kernel-source-515
+Architecture: amd64
+Depends: nvidia-kernel-source-525
+Multi-Arch: foreign
+Description: Transitional package for nvidia-kernel-source-525
+ This is a transitional package for nvidia-kernel-source-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-dkms-515
+Architecture: amd64
+Depends: nvidia-dkms-525
+Multi-Arch: foreign
+Description: Transitional package for nvidia-dkms-525
+ This is a transitional package for nvidia-dkms-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-utils-515
+Architecture: amd64
+Depends: nvidia-utils-525
+Multi-Arch: same
+Description: Transitional package for nvidia-utils-525
+ This is a transitional package for nvidia-utils-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-compute-515
+Architecture: i386 amd64
+Depends: libnvidia-compute-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-compute-525
+ This is a transitional package for libnvidia-compute-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-compute-utils-515
+Architecture: amd64
+Depends: nvidia-compute-utils-525
+Multi-Arch: same
+Description: Transitional package for nvidia-compute-utils-525
+ This is a transitional package for nvidia-compute-utils-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-headless-no-dkms-515
+Architecture: amd64
+Depends: nvidia-headless-no-dkms-525
+Multi-Arch: same
+Description: Transitional package for nvidia-headless-no-dkms-525
+ This is a transitional package for nvidia-headless-no-dkms-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-headless-515
+Architecture: amd64
+Depends: nvidia-headless-525
+Multi-Arch: same
+Description: Transitional package for nvidia-headless-525
+ This is a transitional package for nvidia-headless-525, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-kernel-common-515
+Architecture: amd64
+Depends: nvidia-kernel-common-525
+Multi-Arch: same
+Description: Transitional package for nvidia-kernel-common-525
+ This is a transitional package for nvidia-kernel-common-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-gl-515
+Architecture: i386 amd64
+Depends: libnvidia-gl-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-gl-525
+ This is a transitional package for libnvidia-gl-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-common-515
+Architecture: all
+Depends: libnvidia-common-525
+Multi-Arch: foreign
+Description: Transitional package for libnvidia-common-525
+ This is a transitional package for libnvidia-common-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-extra-515
+Architecture: i386 amd64
+Depends: libnvidia-extra-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-extra-525
+ This is a transitional package for libnvidia-extra-525, and can be
+ safely removed after the installation is complete.
+
+Package: xserver-xorg-video-nvidia-515
+Architecture: amd64
+Depends: xserver-xorg-video-nvidia-525
+Multi-Arch: same
+Description: Transitional package for xserver-xorg-video-nvidia-525
+ This is a transitional package for xserver-xorg-video-nvidia-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-cfg1-515
+Architecture: amd64
+Depends: libnvidia-cfg1-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-cfg1-525
+ This is a transitional package for libnvidia-cfg1-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-fbc1-515
+Architecture: i386 amd64
+Depends: libnvidia-fbc1-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-fbc1-525
+ This is a transitional package for libnvidia-fbc1-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-decode-515
+Architecture: i386 amd64
+Depends: libnvidia-decode-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-decode-525
+ This is a transitional package for libnvidia-decode-525, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-encode-515
+Architecture: i386 amd64
+Depends: libnvidia-encode-525
+Multi-Arch: same
+Description: Transitional package for libnvidia-encode-525
+ This is a transitional package for libnvidia-encode-525, and can be
+ safely removed after the installation is complete.
+
+# 495 Transitional Packaging
+
 Package: nvidia-driver-495
 Architecture: amd64
 Depends: nvidia-driver-525

--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -354,6 +354,146 @@ Description: NVENC Video Encoding runtime library
  .
  This package contains the nvidia-encode runtime library.
 
+# 515 Transitional Packaging
+
+Package: nvidia-driver-515
+Architecture: amd64
+Depends: nvidia-driver-#FLAVOUR#
+Multi-Arch: foreign
+Description: Transitional package for nvidia-driver-#FLAVOUR#
+ This is a transitional package for nvidia-driver-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-kernel-source-515
+Architecture: amd64
+Depends: nvidia-kernel-source-#FLAVOUR#
+Multi-Arch: foreign
+Description: Transitional package for nvidia-kernel-source-#FLAVOUR#
+ This is a transitional package for nvidia-kernel-source-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-dkms-515
+Architecture: amd64
+Depends: nvidia-dkms-#FLAVOUR#
+Multi-Arch: foreign
+Description: Transitional package for nvidia-dkms-#FLAVOUR#
+ This is a transitional package for nvidia-dkms-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-utils-515
+Architecture: amd64
+Depends: nvidia-utils-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for nvidia-utils-#FLAVOUR#
+ This is a transitional package for nvidia-utils-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-compute-515
+Architecture: i386 amd64
+Depends: libnvidia-compute-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-compute-#FLAVOUR#
+ This is a transitional package for libnvidia-compute-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-compute-utils-515
+Architecture: amd64
+Depends: nvidia-compute-utils-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for nvidia-compute-utils-#FLAVOUR#
+ This is a transitional package for nvidia-compute-utils-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-headless-no-dkms-515
+Architecture: amd64
+Depends: nvidia-headless-no-dkms-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for nvidia-headless-no-dkms-#FLAVOUR#
+ This is a transitional package for nvidia-headless-no-dkms-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-headless-515
+Architecture: amd64
+Depends: nvidia-headless-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for nvidia-headless-#FLAVOUR#
+ This is a transitional package for nvidia-headless-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: nvidia-kernel-common-515
+Architecture: amd64
+Depends: nvidia-kernel-common-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for nvidia-kernel-common-#FLAVOUR#
+ This is a transitional package for nvidia-kernel-common-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-gl-515
+Architecture: i386 amd64
+Depends: libnvidia-gl-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-gl-#FLAVOUR#
+ This is a transitional package for libnvidia-gl-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-common-515
+Architecture: all
+Depends: libnvidia-common-#FLAVOUR#
+Multi-Arch: foreign
+Description: Transitional package for libnvidia-common-#FLAVOUR#
+ This is a transitional package for libnvidia-common-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-extra-515
+Architecture: i386 amd64
+Depends: libnvidia-extra-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-extra-#FLAVOUR#
+ This is a transitional package for libnvidia-extra-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: xserver-xorg-video-nvidia-515
+Architecture: amd64
+Depends: xserver-xorg-video-nvidia-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for xserver-xorg-video-nvidia-#FLAVOUR#
+ This is a transitional package for xserver-xorg-video-nvidia-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-cfg1-515
+Architecture: amd64
+Depends: libnvidia-cfg1-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-cfg1-#FLAVOUR#
+ This is a transitional package for libnvidia-cfg1-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-fbc1-515
+Architecture: i386 amd64
+Depends: libnvidia-fbc1-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-fbc1-#FLAVOUR#
+ This is a transitional package for libnvidia-fbc1-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-decode-515
+Architecture: i386 amd64
+Depends: libnvidia-decode-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-decode-#FLAVOUR#
+ This is a transitional package for libnvidia-decode-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+Package: libnvidia-encode-515
+Architecture: i386 amd64
+Depends: libnvidia-encode-#FLAVOUR#
+Multi-Arch: same
+Description: Transitional package for libnvidia-encode-#FLAVOUR#
+ This is a transitional package for libnvidia-encode-#FLAVOUR#, and can be
+ safely removed after the installation is complete.
+
+# 495 Transitional Packaging
+
 Package: nvidia-driver-495
 Architecture: amd64
 Depends: nvidia-driver-#FLAVOUR#


### PR DESCRIPTION
This adds transitional packaging to upgrade 515 driver installs to 525, We will want to delete the 515 repo after this is approved, and release that as the same time as this.
https://github.com/pop-os/nvidia-graphics-drivers-515/tree/transition-515-to-525 is created at the same time as this to disable the build when this branch name is added, the effect being the same as when we delete the repo for release.

This is to keep installs functioning when we release the 6.1.11 kernel