### PR TITLE
fix: add egl-xlib and egl-xcb libraries

### DIFF
--- a/debian/libnvidia-gl-560.install
+++ b/debian/libnvidia-gl-560.install
@@ -31,6 +31,9 @@ NVIDIA-Linux/nvoptix.bin                                   usr/share/nvidia
 #NVIDIA-Linux/32/libGLESv1_CM_nvidia.so.560.35.03               usr/lib/x86_64-linux-gnu
 #NVIDIA-Linux/32/libGLESv2_nvidia.so.560.35.03                  usr/lib/x86_64-linux-gnu
 #NVIDIA-Linux/32/libGLX_nvidia.so.560.35.03                     usr/lib/x86_64-linux-gnu
+#NVIDIA-Linux/32/libnvidia-egl-gbm.so.1.1.1                    usr/lib/x86_64-linux-gnu
+#NVIDIA-Linux/32/libnvidia-egl-xcb.so.1                        usr/lib/x86_64-linux-gnu
+#NVIDIA-Linux/32/libnvidia-egl-xlib.so.1                       usr/lib/x86_64-linux-gnu
 #NVIDIA-Linux/32/libnvidia-eglcore.so.560.35.03                 usr/lib/x86_64-linux-gnu
 #NVIDIA-Linux/32/libnvidia-glcore.so.560.35.03                  usr/lib/x86_64-linux-gnu
 #NVIDIA-Linux/32/libnvidia-glsi.so.560.35.03                    usr/lib/x86_64-linux-gnu

--- a/debian/libnvidia-gl-560.install
+++ b/debian/libnvidia-gl-560.install
@@ -2,6 +2,8 @@ NVIDIA-Linux/_nvngx.dll                                       usr/lib/x86_64-lin
 NVIDIA-Linux/nvngx.dll                                        usr/lib/x86_64-linux-gnu/nvidia/wine
 NVIDIA-Linux/10_nvidia.json                                usr/share/glvnd/egl_vendor.d
 NVIDIA-Linux/15_nvidia_gbm.json                            usr/share/egl/egl_external_platform.d
+NVIDIA-Linux/20_nvidia_xcb.json                            usr/share/egl/egl_external_platform.d
+NVIDIA-Linux/20_nvidia_xlib.json                           usr/share/egl/egl_external_platform.d
 NVIDIA-Linux/libEGL_nvidia.so.560.35.03                    usr/lib/x86_64-linux-gnu
 NVIDIA-Linux/libGLESv1_CM_nvidia.so.560.35.03              usr/lib/x86_64-linux-gnu
 NVIDIA-Linux/libGLESv2_nvidia.so.560.35.03                 usr/lib/x86_64-linux-gnu
@@ -9,6 +11,8 @@ NVIDIA-Linux/libGLX_nvidia.so.560.35.03                    usr/lib/x86_64-linux-
 NVIDIA-Linux/libglxserver_nvidia.so.560.35.03              usr/lib/x86_64-linux-gnu/nvidia/xorg
 NVIDIA-Linux/libnvidia-api.so.1                            usr/lib/x86_64-linux-gnu
 NVIDIA-Linux/libnvidia-egl-gbm.so.1.1.1                    usr/lib/x86_64-linux-gnu
+NVIDIA-Linux/libnvidia-egl-xcb.so.1                        usr/lib/x86_64-linux-gnu
+NVIDIA-Linux/libnvidia-egl-xlib.so.1                       usr/lib/x86_64-linux-gnu
 NVIDIA-Linux/libnvidia-eglcore.so.560.35.03                usr/lib/x86_64-linux-gnu
 NVIDIA-Linux/libnvidia-glcore.so.560.35.03                 usr/lib/x86_64-linux-gnu
 NVIDIA-Linux/libnvidia-glsi.so.560.35.03                   usr/lib/x86_64-linux-gnu

--- a/debian/templates/libnvidia-gl-flavour.install.in
+++ b/debian/templates/libnvidia-gl-flavour.install.in
@@ -2,6 +2,8 @@
 #AMD64_ONLY#NVIDIA-Linux/nvngx.dll                                        #LIBDIR#/nvidia/wine
 #I386_EXCLUDED#NVIDIA-Linux/10_nvidia.json                                usr/share/glvnd/egl_vendor.d
 #I386_EXCLUDED#NVIDIA-Linux/15_nvidia_gbm.json                            usr/share/egl/egl_external_platform.d
+#I386_EXCLUDED#NVIDIA-Linux/20_nvidia_xcb.json                            usr/share/egl/egl_external_platform.d
+#I386_EXCLUDED#NVIDIA-Linux/20_nvidia_xlib.json                           usr/share/egl/egl_external_platform.d
 #I386_EXCLUDED#NVIDIA-Linux/libEGL_nvidia.so.#VERSION#                    #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libGLESv1_CM_nvidia.so.#VERSION#              #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libGLESv2_nvidia.so.#VERSION#                 #LIBDIR#
@@ -9,6 +11,8 @@
 #I386_EXCLUDED#NVIDIA-Linux/libglxserver_nvidia.so.#VERSION#              #LIBDIR#/nvidia/xorg
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-api.so.1                            #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-egl-gbm.so.1.1.1                    #LIBDIR#
+#I386_EXCLUDED#NVIDIA-Linux/libnvidia-egl-xcb.so.1                        #LIBDIR#
+#I386_EXCLUDED#NVIDIA-Linux/libnvidia-egl-xlib.so.1                       #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-eglcore.so.#VERSION#                #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-glcore.so.#VERSION#                 #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-glsi.so.#VERSION#                   #LIBDIR#

--- a/debian/templates/libnvidia-gl-flavour.install.in
+++ b/debian/templates/libnvidia-gl-flavour.install.in
@@ -31,6 +31,9 @@
 #I386_ONLY#NVIDIA-Linux/32/libGLESv1_CM_nvidia.so.#VERSION#               #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libGLESv2_nvidia.so.#VERSION#                  #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libGLX_nvidia.so.#VERSION#                     #LIBDIR#
+#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-gbm.so.1.1.1                    #LIBDIR#
+#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-xcb.so.1                        #LIBDIR#
+#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-xlib.so.1                       #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libnvidia-eglcore.so.#VERSION#                 #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libnvidia-glcore.so.#VERSION#                  #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libnvidia-glsi.so.#VERSION#                    #LIBDIR#


### PR DESCRIPTION
New EGL libraries added to the 560 driver release: https://github.com/NVIDIA/egl-x11
Requires explicit sync for full performance in XWayland
May fix reports of Proton games not working