### PR TITLE
Enable powermanagement parameters on noble

### DIFF
--- a/debian/templates/nvidia-kernel-common-flavour.postinst.in
+++ b/debian/templates/nvidia-kernel-common-flavour.postinst.in
@@ -97,6 +97,12 @@ case "$1" in
                 /usr/sbin/update-initramfs -u -k $CURRENT_KERNEL
             fi
         fi
+
+        OS_MAJOR=$(awk -F'[=."]' '/^VERSION_ID=/ { print $3; }' /etc/os-release)
+        
+        if [ "$OS_MAJOR" -ge "24" ]; then
+            echo "options nvidia NVreg_PreserveVideoMemoryAllocations=1 NVreg_EnableS0ixPowerManagement=1" > /lib/modprobe.d/nvidia-graphics-drivers-sleep.conf
+        fi
         ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
These were previously managed by system76-power, but not any more on noble (without explicit invocation via system76-power, which should be avoided for other reasons).

This seems to work fine on my Pop 24.04. install and indeed fixes the suspend issues we have been seeing. Testing is needed to make sure `/lib/modprobe.d/nvidia-graphics-drivers-sleep.conf` isn't created on 22.04.

