### PR TITLE
perf: improve performance with app profiles

### DIFF
--- a/debian/application-profiles/cuda-no-stable-perf-limit
+++ b/debian/application-profiles/cuda-no-stable-perf-limit
@@ -1,0 +1,32 @@
+{
+    "profiles": [
+        {
+            "name": "CudaNoStablePerfLimit",
+            "settings": ["0x166c5e", 0]
+        }
+    ],
+    "rules": [
+        {
+            "pattern": {
+                "op": "or",
+                "sub": [
+                    { "feature": "procname", "matches": "Discord" },
+                    { "feature": "procname", "matches": "DiscordCanary" },
+                    { "feature": "procname", "matches": "brave" },
+                    { "feature": "procname", "matches": "chrome" },
+                    { "feature": "procname", "matches": "chromium" },
+                    { "feature": "procname", "matches": "discord" },
+                    { "feature": "procname", "matches": "firefox" },
+                    { "feature": "procname", "matches": "gpu-screen-recorder" },
+                    { "feature": "procname", "matches": "obs" },
+                    { "feature": "procname", "matches": "simplescreenrecorder" },
+                    { "feature": "procname", "matches": "spectacle" },
+                    { "feature": "procname", "matches": "vesktop" },
+                    { "feature": "procname", "matches": "webcord" },
+                    { "feature": "procname", "matches": "vivaldi" },
+                ]
+            },
+            "profile": "CudaNoStablePerfLimit"
+        }
+    ]
+}

--- a/debian/application-profiles/vram-limit
+++ b/debian/application-profiles/vram-limit
@@ -1,0 +1,36 @@
+{
+    "rules": [
+        {
+            "pattern": {
+                "op": "or",
+                "sub": [
+                    { "feature": "procname", "matches": "DiscordCanary" },
+                    { "feature": "procname", "matches": "Proton Mail" },
+                    { "feature": "procname", "matches": "Proton Pass" },
+                    { "feature": "procname", "matches": "alacritty" },
+                    { "feature": "procname", "matches": "brave" },
+                    { "feature": "procname", "matches": "chrome" },
+                    { "feature": "procname", "matches": "chromium" },
+                    { "feature": "procname", "matches": "code" },
+                    { "feature": "procname", "matches": "coolercontrol" },
+                    { "feature": "procname", "matches": "cosmic-edit" },
+                    { "feature": "procname", "matches": "cosmic-files" },
+                    { "feature": "procname", "matches": "cosmic-term" },
+                    { "feature": "procname", "matches": "discord" },
+                    { "feature": "procname", "matches": "electron" },
+                    { "feature": "procname", "matches": "firefox" },
+                    { "feature": "procname", "matches": "ghostty" },
+                    { "feature": "procname", "matches": "konsole" },
+                    { "feature": "procname", "matches": "niri" },
+                    { "feature": "procname", "matches": "spotify" },
+                    { "feature": "procname", "matches": "vesktop" },
+                    { "feature": "procname", "matches": "vivaldi" },
+                    { "feature": "procname", "matches": "webcord" },
+                    { "feature": "procname", "matches": "yakuake" },
+                    { "feature": "procname", "matches": "zed-editor" }
+                ]
+            },
+            "profile": "No VidMem Reuse"
+        }
+    ]
+}

--- a/debian/libnvidia-common-580.install
+++ b/debian/libnvidia-common-580.install
@@ -1,3 +1,9 @@
 NVIDIA-Linux/nvidia-application-profiles-580.126.18-key-documentation        usr/share/nvidia
 NVIDIA-Linux/nvidia-application-profiles-580.126.18-rc                       usr/share/nvidia
 NVIDIA-Linux/sandboxutils-filelist.json                                     usr/share/nvidia/files.d/
+# Allows full performance while streaming/recording: NVIDIA/open-gpu-kernel-modules#333
+# Based on https://github.com/Frogging-Family/nvidia-all/blob/master/system/cuda-no-stable-perf-limit
+debian/application-profiles/cuda-no-stable-perf-limit                       usr/share/nvidia/nvidia-application-profiles-rc.d/
+# Limit VRAM usage of desktop apps that don't benefit from it
+# Based on patch from NextWork123: https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/873
+debian/application-profiles/vram-limit                                      usr/share/nvidia/nvidia-application-profiles-rc.d/

--- a/debian/templates/libnvidia-common-flavour.install.in
+++ b/debian/templates/libnvidia-common-flavour.install.in
@@ -1,3 +1,9 @@
 #I386_EXCLUDED#NVIDIA-Linux/nvidia-application-profiles-#VERSION#-key-documentation        usr/share/nvidia
 #I386_EXCLUDED#NVIDIA-Linux/nvidia-application-profiles-#VERSION#-rc                       usr/share/nvidia
 #I386_EXCLUDED#NVIDIA-Linux/sandboxutils-filelist.json                                     usr/share/nvidia/files.d/
+# Allows full performance while streaming/recording: NVIDIA/open-gpu-kernel-modules#333
+# Based on https://github.com/Frogging-Family/nvidia-all/blob/master/system/cuda-no-stable-perf-limit
+#I386_EXCLUDED#debian/application-profiles/cuda-no-stable-perf-limit                       usr/share/nvidia/nvidia-application-profiles-rc.d/
+# Limit VRAM usage of desktop apps that don't benefit from it
+# Based on patch from NextWork123: https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/873
+#I386_EXCLUDED#debian/application-profiles/vram-limit                                      usr/share/nvidia/nvidia-application-profiles-rc.d/


### PR DESCRIPTION
Limits VRAM usage of desktop apps that do not benefit from hoarding VRAM. Also ensures that streaming/recording software can use NVENC/NVDEC without causing the GPU to consume a lot of power (NVIDIA/open-gpu-kernel-modules#333).

- Adds https://github.com/Frogging-Family/nvidia-all/blob/master/system/limit-vram-usage
- Adds https://github.com/Frogging-Family/nvidia-all/blob/master/system/cuda-no-stable-perf-limit

Adjusted to add vivaldi, zed-editor, and some cosmic apps.